### PR TITLE
Added optional `headers` kwarg to API & python3.6+ compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ output/
 build/
 
 .DS_Store
+
+
+# PyCharm
+.idea/*


### PR DESCRIPTION
I put `headers=None` as an **optional** keyword for the python API. I used `requests.utils.default_headers()` to basically emulate the default-behavior of `requests.get()`, but with the added-bonus of being able to change it if you want!  
Started @ the globabl `analyze()` func but needed to add a `self.headers` param to the `Page()` object.  

&&  

As of python3.6 the `unicode` keyword doesn't exist!  
This is b/c the python foundation apparently wants to...(kill?...hmmm that isn't really a strong enough word...) completely-annihilate any chances of backwards-compatibility with python2!