### PR TITLE
fix html generation when facebook is not in the context

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ output = analyze(site, sitemap)
 print(output)
 ```
 
+Alternatively, you can run the analysis as a script from the seoanalyzer folder.
+
+```console
+rocketoc:~$ python3 analyzer.py https://www.sethserver.com/ -f html > results.html
+```
 
 Notes:
 ------

--- a/README.md
+++ b/README.md
@@ -48,13 +48,6 @@ output = analyze(site, sitemap)
 print(output)
 ```
 
-Alternatively, you can run the analysis as a script from the seoanalyzer folder.
-
-```console
-rocketoc:~$ python3 analyzer.py https://www.sethserver.com/ -f html > results.html
-
-```
-
 
 Notes:
 ------

--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ from seoanalyzer import analyze
 output = analyze(site, sitemap)
 
 print(output)
-```  
+```
+
+Alternatively, you can run the analysis as a script from the seoanalyzer folder.
+
+```console
+rocketoc:~$ python3 analyzer.py https://www.sethserver.com/ -f html > results.html
+
+```
+
 
 Notes:
 ------

--- a/seoanalyzer/analyzer.py
+++ b/seoanalyzer/analyzer.py
@@ -8,7 +8,6 @@ from urllib.parse import urlsplit
 from xml.dom import minidom
 from requests.structures import CaseInsensitiveDict
 
-from seoanalyzer.stemmer import stem
 
 import argparse
 import json
@@ -19,6 +18,11 @@ import requests
 import socket
 import time
 import os
+
+try:
+    from seoanalyzer.stemmer import stem
+except ImportError:
+    from stemmer import stem
 
 ##
 # python 3.6+ support.

--- a/seoanalyzer/analyzer.py
+++ b/seoanalyzer/analyzer.py
@@ -8,7 +8,7 @@ from urllib.parse import urlsplit
 from xml.dom import minidom
 from requests.structures import CaseInsensitiveDict
 
-from seoanalyzer.stemmer import stem
+from stemmer import stem
 
 import argparse
 import json

--- a/seoanalyzer/analyzer.py
+++ b/seoanalyzer/analyzer.py
@@ -8,7 +8,7 @@ from urllib.parse import urlsplit
 from xml.dom import minidom
 from requests.structures import CaseInsensitiveDict
 
-from stemmer import stem
+from seoanalyzer.stemmer import stem
 
 import argparse
 import json

--- a/seoanalyzer/templates/index.html
+++ b/seoanalyzer/templates/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 <head>
 	<meta charset="utf-8">
@@ -66,26 +66,38 @@
 						<!-- <th class="error-detail">notices</th> -->
 					</tr>
 				</thead>
+
+				<tbody>
 				{% for page in result['pages']%}
 				{% set outer_loop = loop %}
-				{% for key in page.keys() %}
 				<tr onclick="fullerrors({{ outer_loop.index }})">
 					<td><i class="material-icons" id="i{{ outer_loop.index }}">keyboard_arrow_down</i></td>
-					<td><a href="{{ key }}" target ="_blank">{{key}}</a></td>
-					<td>{{page[key][0]['facebook']['shares']}}</td>
-					<td>{{page[key][0]['facebook']['clicks']}}</td>
-					<td>{{page[key][0]['facebook']['likes']}}</td>
-					<td>{{page[key][0]['facebook']['comments']}}</td>
-					<td>{{page[key][0]['stumbleupon']['stumbles']}}</td>
-					<td>{{page[key][1]|length}}</td>
-					<!-- <td class="error-detail"><ul>{% for err in page[key][1] %}<li>{{err|e}}</li>{% endfor %}</ul></td> -->
+					<td><a href="{{ page['url'] }}" target ="_blank">{{page['url']}}</a></td>
+					{% if 'facebook' in page %}
+ 					<td>{{page['facebook']['shares']}}</td>
+					<td>{{page['facebook']['clicks']}}</td>
+					<td>{{page['facebook']['likes']}}</td>
+					<td>{{page['facebook']['comments']}}</td>
+					{% else %}
+					<td>N/A</td>
+					<td>N/A</td>
+					<td>N/A</td>
+					<td>N/A</td>
+					{% endif %}
+					{% if 'stumbleupon' in page %}
+					<td>{{page['stumbleupon']['stumbles']}}</td>
+					{%else%}
+					<td>N/A</td>
+					{% endif %}
+					<td>{{page["warnings"]|length}}</td>
 				</tr>
 				<tr id="{{ outer_loop.index }}" class="error-detail">
-					<td></td>
-					<td colspan="7"><ul>{% for err in page[key][1] %}<li>{{err|e}}</li>{% endfor %}</ul></td>
+					{% if page["warnings"]|length > 1 %}
+					<td colspan="7"><ul>{% for err in page["warnings"] %}<li>{{err|e}}</li>{% endfor %}</ul></td>
+					{% endif %}
 				</tr>
 				{% endfor %}
-				{% endfor %}
+			</tbody>
 			</table>
 			</div>
 
@@ -102,6 +114,7 @@
 						<th class="sortable_th">count</th>
 					</tr>
 				</thead>
+				<tbody>
 				{% for key in result['keywords']%}
 				<tr>
 					<td> {{ key['word'] }} </td>
@@ -109,6 +122,7 @@
 				</tr>
 
 				{% endfor %}
+			</tbody>
 			</table>
 		</div>
 			{% endif %}


### PR DESCRIPTION
- The html generation was failing when the facebook metrics were missing for a page
- The html generation was failing when the stumble metrics were missing for a page

Tests Run:
$ python3 analyzer.py http://www.triggerfreemedia.com/scanner/ -f html > output.html
$ python3 analyzer.py https://www.sethserver.com/ -f html > output.html