### PR TITLE
feat: add docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3-alpine
+
+WORKDIR /app
+
+COPY . /app
+
+RUN python3 setup.py install
+
+ENTRYPOINT ["/usr/local/bin/seoanalyze"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Installation
 pip3 install pyseoanalyzer
 ```
 
+### Docker
+
+```
+docker run sethblack/python-seo-analyzer [ARGS ...]
+```
+
 Command-line Usage
 ------------------
 


### PR DESCRIPTION
This permit to run pyhton-seo-analyser without have to setup python and install deps.

You will just have to create a docker account with the name of `sethblack` and create a repository called: `python-seo-analyzer`.

Once it's done, you will be able to configure the automatic build of your Docker Image( for each release for example ) !

I'm available if you need help