### PR TITLE
Added all existing analyze options as arguments

### DIFF
--- a/seoanalyzer/__main__.py
+++ b/seoanalyzer/__main__.py
@@ -21,9 +21,13 @@ def main(args=None):
         arg_parser.add_argument('-f', '--output-format', help='Output format.', choices=['json', 'html', ],
                                 default='json')
 
+        arg_parser.add_argument('--analyze-headings', default=False, action='store_true', help='Analyze heading tags (h1-h6).')
+        arg_parser.add_argument('--analyze-extra-tags', default=False, action='store_true', help='Analyze other extra additional tags.')
+        arg_parser.add_argument('--no-follow-links', default=True, action='store_false', help='Analyze all the existing inner links as well (might be time consuming).')
+
         args = arg_parser.parse_args()
 
-        output = analyze(args.site, args.sitemap)
+        output = analyze(args.site, args.sitemap, analyze_headings=args.analyze_headings, analyze_extra_tags=args.analyze_extra_tags, follow_links=args.no_follow_links)
 
         if args.output_format == 'html':
             from jinja2 import Environment


### PR DESCRIPTION
Using the README and code informations, I added the available `analyze()` options/arguments as arguments for the tool/cli

Now what we could achieve by code only (`output = analyze(site, sitemap, follow_links=False)` or `output = analyze(site, sitemap, analyze_headings=True, analyze_extra_tags=True)`, or both) is available from the cli

| Argument | Default | Description |
|---|---|---|
| --analyze-headings | False | Analyze heading tags (h1-h6). |
| --analyze-extra-tags | False | Analyze other extra additional tags. |
| --no-follow-links | True | Analyze all the existing inner links as well (might be time consuming). |

### Examples
```shell
# original command with defaults (no headings, no extra tags, and follow links)
docker run sethblack/python-seo-analyzer http://host.docker.internal:8080/ --output-format html  > results.html

# analyze command with headings, extra tags, and follow links
docker run sethblack/python-seo-analyzer http://host.docker.internal:8080/ --analyze-headings --analyze-extra-tags --output-format html  > results.html

# analyze with headings, extra tags, but without follow links
docker run sethblack/python-seo-analyzer http://host.docker.internal:8080/ --analyze-headings --analyze-extra-tags --no-follow-links --output-format html  > results.html

# analyze without headings, without extra tags, and without follow links)
docker run sethblack/python-seo-analyzer http://host.docker.internal:8080/ --no-follow-links --output-format html  > results.html
```