### PR TITLE
fix: correctly handle non-UTF-8 charsets in Content-Type header

### DIFF
--- a/pyseoanalyzer/page.py
+++ b/pyseoanalyzer/page.py
@@ -203,16 +203,17 @@ class Page:
                 self.warn(f"Returned {e}")
                 return
 
-            encoding = "utf8"
+            encoding = self.encoding
 
             if "content-type" in page.headers:
-                encoding = page.headers["content-type"].split("charset=")[-1]
+                content_type = page.headers["content-type"]
+                if not any(t in content_type for t in ("text/html", "text/plain")):
+                    self.warn(f"Can not read {content_type}")
+                    return
+                if "charset=" in content_type:
+                    encoding = content_type.split("charset=")[-1].strip()
 
-            if encoding.lower() not in ("text/html", "text/plain", self.encoding):
-                self.warn(f"Can not read {encoding}")
-                return
-            else:
-                raw_html = page.data.decode(self.encoding)
+            raw_html = page.data.decode(encoding, errors="replace")
 
         self.content_hash = hashlib.sha1(raw_html.encode(self.encoding)).hexdigest()
 


### PR DESCRIPTION
There are two related bugs in the encoding detection block inside `Page.analyze()`:

1. When the response has a non-UTF-8 charset (e.g. `Content-Type: text/html; charset=iso-8859-1`), the extracted encoding value (`iso-8859-1`) is checked against a list of content-type strings (`"text/html"`, `"text/plain"`, `self.encoding`). Since `iso-8859-1` is not in that list, the page is incorrectly rejected with "Can not read iso-8859-1". Same issue with `windows-1252` and any other non-UTF-8 encoding.

2. Even when the check passes, the decode always uses `self.encoding` (default `utf-8`) and ignores the charset that was just extracted from the header. So even if someone overrides `self.encoding`, non-UTF-8 pages would still decode incorrectly.

Bonus: when there is no `content-type` header at all, `encoding` stays as `"utf8"` (without a hyphen), which also fails the `not in` check since `"utf8"` != `"utf-8"`, causing those pages to be incorrectly rejected too.

Fix:
- Check the content-type value itself (does it contain `text/html` or `text/plain`) instead of checking the extracted charset string
- Only extract the charset when `charset=` is actually present in the header
- Decode using the extracted charset (falling back to `self.encoding`)
- Add `errors="replace"` to handle any remaining edge cases gracefully