### PR TITLE
feat: add max_pages parameter to limit crawl size for large sites

### DIFF
--- a/pyseoanalyzer/__main__.py
+++ b/pyseoanalyzer/__main__.py
@@ -57,6 +57,12 @@ def main():
         action="store_true",
         help="Run LLM analysis on the content.",
     )
+    arg_parser.add_argument(
+        "--max-pages",
+        default=None,
+        type=int,
+        help="Maximum number of pages to crawl. Useful for large sites.",
+    )
 
     args = arg_parser.parse_args()
 
@@ -67,6 +73,7 @@ def main():
         analyze_extra_tags=args.analyze_extra_tags,
         follow_links=args.no_follow_links,
         run_llm_analysis=args.run_llm_analysis,
+        max_pages=args.max_pages,
     )
 
     if args.output_format == "html":

--- a/pyseoanalyzer/analyzer.py
+++ b/pyseoanalyzer/analyzer.py
@@ -14,6 +14,7 @@ def analyze(
     analyze_extra_tags=False,
     follow_links=True,
     run_llm_analysis=False,
+    max_pages=None,
 ):
     start_time = time.time()
 
@@ -31,6 +32,7 @@ def analyze(
         analyze_extra_tags=analyze_extra_tags,
         follow_links=follow_links,
         run_llm_analysis=run_llm_analysis,
+        max_pages=max_pages,
     )
 
     site.crawl()

--- a/pyseoanalyzer/website.py
+++ b/pyseoanalyzer/website.py
@@ -16,6 +16,7 @@ class Website:
         analyze_extra_tags=False,
         follow_links=False,
         run_llm_analysis=False,
+        max_pages=None,
     ):
         self.base_url = base_url
         self.sitemap = sitemap
@@ -23,6 +24,7 @@ class Website:
         self.analyze_extra_tags = analyze_extra_tags
         self.follow_links = follow_links
         self.run_llm_analysis = run_llm_analysis
+        self.max_pages = max_pages
         self.crawled_pages = []
         self.crawled_urls = set()
         self.page_queue = []
@@ -94,6 +96,10 @@ class Website:
 
                     self.crawled_pages.append(page)
                     self.crawled_urls.add(page.url)
+
+                    # Stop if we've reached the maximum number of pages
+                    if self.max_pages is not None and len(self.crawled_pages) >= self.max_pages:
+                        break
 
                 # Stop after the first page if not following links, regardless of analysis success
                 if not self.follow_links:


### PR DESCRIPTION
## Summary

Adds a `max_pages` parameter that caps the number of pages crawled, allowing users to analyze large sites in manageable batches. This prevents the multi-hundred-MB output files reported in #114 when crawling sites with thousands of pages.

## Changes

- **`pyseoanalyzer/website.py`**: Added `max_pages` parameter to `Website.__init__()`. After each successful page crawl, the loop checks `len(self.crawled_pages)` against `self.max_pages` and breaks early if the limit is reached.

- **`pyseoanalyzer/analyzer.py`**: Added `max_pages=None` to the `analyze()` function signature and passes it through to the `Website` constructor.

- **`pyseoanalyzer/__main__.py`**: Added `--max-pages` CLI argument (`type=int`, default `None`) and passes it to `analyze()`.

## Pattern

Follows the exact same three-layer plumbing pattern as existing optional parameters (`analyze_headings`, `follow_links`, `run_llm_analysis`) — CLI argument → `analyze()` kwargs → `Website.__init__()`. When `None` (the default), behavior is completely unchanged and the full site is crawled as before.