### PR TITLE
Add AI crawler access check (llms.txt + robots.txt AI bot detection)

### DIFF
--- a/pyseoanalyzer/analyzer.py
+++ b/pyseoanalyzer/analyzer.py
@@ -23,6 +23,7 @@ def analyze(
         "keywords": [],
         "errors": [],
         "total_time": 0,  # Initialize to 0 before calculation
+        "ai_crawler_access": {},
     }
 
     site = Website(
@@ -36,6 +37,8 @@ def analyze(
     )
 
     site.crawl()
+
+    output["ai_crawler_access"] = site.ai_crawler_access
 
     for p in site.crawled_pages:
         output["pages"].append(p.as_dict())

--- a/pyseoanalyzer/website.py
+++ b/pyseoanalyzer/website.py
@@ -7,6 +7,21 @@ from .http import http
 from .page import Page
 
 
+# User-agent tokens for AI crawlers/agents that read a site's robots.txt to
+# decide whether they may fetch it. Not exhaustive, but covers the major
+# training and retrieval crawlers as of 2026.
+AI_CRAWLER_USER_AGENTS = [
+    "GPTBot",
+    "ChatGPT-User",
+    "OAI-SearchBot",
+    "ClaudeBot",
+    "Claude-User",
+    "anthropic-ai",
+    "PerplexityBot",
+    "Google-Extended",
+]
+
+
 class Website:
     def __init__(
         self,
@@ -32,6 +47,11 @@ class Website:
         self.bigrams = Counter()
         self.trigrams = Counter()
         self.content_hashes = defaultdict(set)
+        self.ai_crawler_access = {
+            "llms_txt": False,
+            "robots_txt_found": False,
+            "blocked_ai_bots": [],
+        }
 
     def check_dns(self, url_to_check):
         try:
@@ -49,7 +69,67 @@ class Website:
             node.data for node in nodelist if node.nodeType == node.TEXT_NODE
         )
 
+    def check_ai_crawler_access(self):
+        """
+        Checks whether the site publishes an llms.txt file and whether its
+        robots.txt explicitly disallows any of the well-known AI crawler
+        user-agents (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, etc).
+
+        Returns a dict:
+            {
+                "llms_txt": bool,
+                "robots_txt_found": bool,
+                "blocked_ai_bots": [str, ...],
+            }
+        """
+        result = {
+            "llms_txt": False,
+            "robots_txt_found": False,
+            "blocked_ai_bots": [],
+        }
+
+        base = self.base_url.rstrip("/")
+
+        try:
+            llms_response = http.get(f"{base}/llms.txt")
+            result["llms_txt"] = llms_response.status == 200
+        except Exception:
+            pass
+
+        try:
+            robots_response = http.get(f"{base}/robots.txt")
+            if robots_response.status == 200:
+                result["robots_txt_found"] = True
+                robots_txt = robots_response.data.decode("utf-8", errors="ignore")
+
+                current_agents = []
+                for line in robots_txt.splitlines():
+                    line = line.split("#", 1)[0].strip()
+                    if not line or ":" not in line:
+                        continue
+
+                    field, _, value = line.partition(":")
+                    field = field.strip().lower()
+                    value = value.strip()
+
+                    if field == "user-agent":
+                        current_agents = [value]
+                    elif field == "disallow" and value == "/" and current_agents:
+                        for agent in current_agents:
+                            for bot in AI_CRAWLER_USER_AGENTS:
+                                if (
+                                    agent.lower() == bot.lower()
+                                    and bot not in result["blocked_ai_bots"]
+                                ):
+                                    result["blocked_ai_bots"].append(bot)
+        except Exception:
+            pass
+
+        return result
+
     def crawl(self):
+        self.ai_crawler_access = self.check_ai_crawler_access()
+
         try:
             if self.sitemap:
                 page = http.get(self.sitemap)

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -1,0 +1,40 @@
+from pyseoanalyzer.website import Website
+
+
+def test_check_ai_crawler_access_allows_and_has_llms_txt():
+    site = Website(
+        base_url="https://alexander-k-eliot.github.io/ai-visibility-check-free/",
+        sitemap=None,
+    )
+
+    result = site.check_ai_crawler_access()
+
+    assert result["robots_txt_found"] is True
+    assert result["llms_txt"] is True
+    assert result["blocked_ai_bots"] == []
+
+
+def test_check_ai_crawler_access_detects_blocked_bots():
+    site = Website(
+        base_url="https://wilreynolds.com/",
+        sitemap=None,
+    )
+
+    result = site.check_ai_crawler_access()
+
+    assert result["robots_txt_found"] is True
+    assert "GPTBot" in result["blocked_ai_bots"]
+    assert "ClaudeBot" in result["blocked_ai_bots"]
+
+
+def test_website_init_sets_default_ai_crawler_access():
+    site = Website(
+        base_url="https://example.com/",
+        sitemap=None,
+    )
+
+    assert site.ai_crawler_access == {
+        "llms_txt": False,
+        "robots_txt_found": False,
+        "blocked_ai_bots": [],
+    }


### PR DESCRIPTION
Adds Website.check_ai_crawler_access(), which checks for a published /llms.txt and parses /robots.txt for explicit Disallow rules against the major AI crawler user-agents (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, etc). Wired into analyze()'s output as output['ai_crawler_access']. Includes 3 new tests, verified passing against two real live sites (one that allows all AI crawlers and publishes llms.txt, one that explicitly blocks several). Ran the existing test suite before and after: 3 pre-existing failures (a stale 'max_pages' kwarg assertion, unrelated to this change) are present identically on a clean checkout of main, confirmed no new regressions.