### PR TITLE
Split AI crawler check into training vs retrieval/citation categories

### DIFF
--- a/pyseoanalyzer/website.py
+++ b/pyseoanalyzer/website.py
@@ -10,16 +10,30 @@ from .page import Page
 # User-agent tokens for AI crawlers/agents that read a site's robots.txt to
 # decide whether they may fetch it. Not exhaustive, but covers the major
 # training and retrieval crawlers as of 2026.
-AI_CRAWLER_USER_AGENTS = [
+#
+# These fall into two independently-controlled categories per each vendor's
+# own docs: training crawlers (build model training data) and retrieval/
+# citation crawlers (fetch a page live to answer a specific query or cite
+# it). Blocking training alone is a legitimate, defensible policy choice.
+# Blocking a retrieval crawler is what actually removes a site from an
+# assistant's answers/citations -- and it's frequently accidental, the
+# result of a blanket "block AI scraping" pass that never revisited the
+# distinction. Pooling both into a single "blocked" signal hides that.
+AI_CRAWLER_TRAINING_BOTS = [
     "GPTBot",
-    "ChatGPT-User",
-    "OAI-SearchBot",
-    "ClaudeBot",
-    "Claude-User",
-    "anthropic-ai",
-    "PerplexityBot",
     "Google-Extended",
+    "ClaudeBot",
+    "anthropic-ai",
 ]
+
+AI_CRAWLER_RETRIEVAL_BOTS = [
+    "OAI-SearchBot",
+    "ChatGPT-User",
+    "PerplexityBot",
+    "Claude-User",
+]
+
+AI_CRAWLER_USER_AGENTS = AI_CRAWLER_TRAINING_BOTS + AI_CRAWLER_RETRIEVAL_BOTS
 
 
 class Website:
@@ -51,6 +65,8 @@ class Website:
             "llms_txt": False,
             "robots_txt_found": False,
             "blocked_ai_bots": [],
+            "blocked_training_bots": [],
+            "blocked_retrieval_bots": [],
         }
 
     def check_dns(self, url_to_check):
@@ -73,19 +89,26 @@ class Website:
         """
         Checks whether the site publishes an llms.txt file and whether its
         robots.txt explicitly disallows any of the well-known AI crawler
-        user-agents (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, etc).
+        user-agents (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, etc),
+        split into training crawlers vs. retrieval/citation crawlers -- see
+        the module-level comment on AI_CRAWLER_TRAINING_BOTS for why that
+        split matters.
 
         Returns a dict:
             {
                 "llms_txt": bool,
                 "robots_txt_found": bool,
-                "blocked_ai_bots": [str, ...],
+                "blocked_ai_bots": [str, ...],       # all blocked bots, unchanged for compatibility
+                "blocked_training_bots": [str, ...],  # subset: training-only crawlers
+                "blocked_retrieval_bots": [str, ...], # subset: retrieval/citation crawlers
             }
         """
         result = {
             "llms_txt": False,
             "robots_txt_found": False,
             "blocked_ai_bots": [],
+            "blocked_training_bots": [],
+            "blocked_retrieval_bots": [],
         }
 
         base = self.base_url.rstrip("/")
@@ -122,6 +145,10 @@ class Website:
                                     and bot not in result["blocked_ai_bots"]
                                 ):
                                     result["blocked_ai_bots"].append(bot)
+                                    if bot in AI_CRAWLER_TRAINING_BOTS:
+                                        result["blocked_training_bots"].append(bot)
+                                    elif bot in AI_CRAWLER_RETRIEVAL_BOTS:
+                                        result["blocked_retrieval_bots"].append(bot)
         except Exception:
             pass
 

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -12,6 +12,8 @@ def test_check_ai_crawler_access_allows_and_has_llms_txt():
     assert result["robots_txt_found"] is True
     assert result["llms_txt"] is True
     assert result["blocked_ai_bots"] == []
+    assert result["blocked_training_bots"] == []
+    assert result["blocked_retrieval_bots"] == []
 
 
 def test_check_ai_crawler_access_detects_blocked_bots():
@@ -27,6 +29,35 @@ def test_check_ai_crawler_access_detects_blocked_bots():
     assert "ClaudeBot" in result["blocked_ai_bots"]
 
 
+def test_check_ai_crawler_access_separates_training_and_retrieval():
+    # wilreynolds.com blocks all 4 training crawlers (GPTBot, Google-Extended,
+    # ClaudeBot, anthropic-ai) plus one retrieval crawler (PerplexityBot), but
+    # allows OAI-SearchBot/ChatGPT-User/Claude-User -- a real, live example of
+    # exactly the mixed case the split is meant to surface.
+    site = Website(
+        base_url="https://wilreynolds.com/",
+        sitemap=None,
+    )
+
+    result = site.check_ai_crawler_access()
+
+    assert set(result["blocked_training_bots"]) == {
+        "GPTBot",
+        "Google-Extended",
+        "ClaudeBot",
+        "anthropic-ai",
+    }
+    assert result["blocked_retrieval_bots"] == ["PerplexityBot"]
+    # every blocked bot must land in exactly one category, and the union
+    # must equal the unchanged, backward-compatible blocked_ai_bots list
+    assert set(result["blocked_training_bots"]) | set(
+        result["blocked_retrieval_bots"]
+    ) == set(result["blocked_ai_bots"])
+    assert set(result["blocked_training_bots"]).isdisjoint(
+        result["blocked_retrieval_bots"]
+    )
+
+
 def test_website_init_sets_default_ai_crawler_access():
     site = Website(
         base_url="https://example.com/",
@@ -37,4 +68,6 @@ def test_website_init_sets_default_ai_crawler_access():
         "llms_txt": False,
         "robots_txt_found": False,
         "blocked_ai_bots": [],
+        "blocked_training_bots": [],
+        "blocked_retrieval_bots": [],
     }


### PR DESCRIPTION
Follow-up to #130.

Training crawlers (`GPTBot`, `Google-Extended`, `ClaudeBot`, `anthropic-ai`) and retrieval/citation crawlers (`OAI-SearchBot`, `ChatGPT-User`, `PerplexityBot`, `Claude-User`) have independent robots.txt controls per each vendor's own docs. The current check pools any blocked bot into one flat `blocked_ai_bots` list, which hides a common real-world mistake: a site blanket-disallows "AI scraping" and takes out the retrieval agent that actually produces a citation along with the training crawler, without ever revisiting the distinction later. Blocking training alone is a legitimate, defensible policy choice and probably should not read the same as losing citability.

This adds `blocked_training_bots` and `blocked_retrieval_bots` alongside the existing `blocked_ai_bots` (kept unchanged for backward compatibility, so nothing consuming the old field breaks).

I ran into this exact gap in my own, unrelated project's AI-visibility checker after a Reddit conversation about the same distinction, then noticed this repo's check had it too, so figured a fix was worth sending back.

Tested against two real, live sites (not mocked): my own site (open to all listed crawlers) and wilreynolds.com (blocks all 4 training crawlers plus PerplexityBot, but allows OAI-SearchBot/ChatGPT-User/Claude-User — a real example of exactly the mixed case this surfaces). New test added for the split; the 3 pre-existing test failures in `test_analyzer.py`/`test_llm_analyst.py`/`test_page.py` (missing `ANTHROPIC_API_KEY`, an unrelated dict-shape mismatch) are present on `main` too and unrelated to this change.